### PR TITLE
feat: Add new voicevox tools and update client

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -16,7 +16,7 @@ from mcp.server.models import InitializationOptions
 from src.mcp_server import MCPServer
 
 # ロギングの設定
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.DEBUG)  # DEBUG レベルに変更
 logger = logging.getLogger(__name__)
 
 
@@ -69,7 +69,7 @@ def main():
     server = MCPServer(
         host=args.host,
         port=args.port,
-        speaker=args.speaker
+        default_speaker=args.speaker
     )
     
     # サーバーの実行

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -11,11 +11,13 @@ import os
 import wave
 from datetime import datetime
 from io import BytesIO
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List # List を追加
 import wave, simpleaudio as sa
+import base64 # base64 を追加
 
 import sounddevice as sd
 from mcp.server import Server
+from mcp import types # types を直接 import
 
 from src.voicevox_client import VoicevoxClient
 
@@ -37,7 +39,7 @@ class MCPServer(Server):
         name: str = "voicevox-mcp-light",
         host: Optional[str] = None,
         port: Optional[str] = None,
-        speaker: Optional[str] = None,
+        default_speaker: Optional[str] = None, # speaker を default_speaker に変更
     ):
         """
         MCPServerクラスの初期化メソッド。
@@ -46,12 +48,12 @@ class MCPServer(Server):
             name: サーバー名
             host: voicevoxエンジンのホスト名
             port: voicevoxエンジンのポート番号
-            speaker: 話者ID
+            default_speaker: デフォルトの話者ID
         """
         super().__init__(name)
         
         # VoicevoxClientの初期化
-        self.voicevox_client = VoicevoxClient(host=host, port=port, speaker=speaker)
+        self.voicevox_client = VoicevoxClient(host=host, port=port, default_speaker=default_speaker) # speaker を default_speaker に変更
         
         # ロガーの設定
         self.logger = self._setup_logger()
@@ -101,7 +103,7 @@ class MCPServer(Server):
         Returns:
             サーバーの機能を表す辞書
         """
-        from mcp.server.lowlevel import NotificationOptions
+        from mcp.server.lowlevel import NotificationOptions # types を直接 import するため修正
         
         if notification_options is None:
             notification_options = NotificationOptions()
@@ -129,7 +131,7 @@ class MCPServer(Server):
         @self.list_tools()
         async def handle_list_tools():
             """利用可能なツールの一覧を返します。"""
-            from mcp import types
+            # types を直接 import するため修正
             return [
                 types.Tool(
                     name="synthesizeAndPlay",
@@ -137,62 +139,158 @@ class MCPServer(Server):
                     inputSchema={
                         "type": "object",
                         "properties": {
-                            "message": {"type": "string", "description": "音声合成するテキスト"}
+                            "message": {"type": "string", "description": "音声合成するテキスト"},
+                            "speaker": {"type": "string", "description": "（オプショナル）話者ID"}
                         },
                         "required": ["message"]
+                    }
+                ),
+                types.Tool(
+                    name="audio_query",
+                    description="テキストから音声合成用のクエリを生成します",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "text": {"type": "string", "description": "クエリを生成するテキスト"},
+                            "speaker": {"type": "string", "description": "（オプショナル）話者ID"}
+                        },
+                        "required": ["text"]
+                    },
+                    outputSchema={ # outputSchema を追加
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "object", "description": "音声合成用クエリ"}
+                        }
+                    }
+                ),
+                types.Tool(
+                    name="synthesis",
+                    description="音声合成用のクエリからWAV音声データを生成します",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "object", "description": "音声合成用クエリ"},
+                            "speaker": {"type": "string", "description": "（オプショナル）話者ID"}
+                        },
+                        "required": ["query"]
+                    },
+                    outputSchema={ # outputSchema を追加
+                        "type": "object",
+                        "properties": {
+                            "audio_content": {"type": "string", "format": "byte", "description": "Base64エンコードされたWAV音声データ"}
+                        }
+                    }
+                ),
+                types.Tool(
+                    name="speakers",
+                    description="利用可能な話者の一覧を取得します",
+                    inputSchema={}, # inputSchema を空のobjectに変更
+                    outputSchema={ # outputSchema を追加
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "speaker_uuid": {"type": "string"},
+                                "styles": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {"type": "string"},
+                                            "id": {"type": "integer"}
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 )
             ]
         
-        # synthesizeAndPlayツールの登録
         @self.call_tool()
-        async def synthesizeAndPlay(name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        async def handle_call_tool(name: str, arguments: Dict[str, Any]) -> List[types.Content]: # 戻り値の型ヒントを修正
             """
-            テキストを音声合成して再生します。
-            
-            Args:
-                name: ツール名
-                arguments: ツールの引数
-            
-            Returns:
-                処理結果を含む辞書
+            指定されたツールを実行します。
             """
-            from mcp import types
-            
-            # ツール名のチェック
-            if name != "synthesizeAndPlay":
-                self.logger.warning(f"Unknown tool: {name}")
-                return [types.TextContent(type="text", text=f"Unknown tool: {name}")]
-            
-            message = arguments.get("message", "")
-            if not message:
-                self.logger.warning("Empty message received")
-                return [types.TextContent(type="text", text="Message is empty")]
-            
+            self.logger.info(f"Tool called: {name} with arguments: {arguments}")
             try:
-                await self.synthesize_and_play(message)
-                return [types.TextContent(type="text", text="音声合成と再生が完了しました")]
-            except Exception as e:
-                self.logger.error(f"Error in synthesizeAndPlay: {str(e)}")
-                return [types.TextContent(type="text", text=f"Error: {str(e)}")]
+                if name == "synthesizeAndPlay":
+                    message = arguments.get("message", "")
+                    speaker = arguments.get("speaker") 
+                    if not message:
+                        self.logger.warning("Empty message received for synthesizeAndPlay")
+                        return [types.TextContent(type="text", text="Message is empty")]
+                    await self.synthesize_and_play(message, speaker)
+                    return [types.TextContent(type="text", text="音声合成と再生が完了しました")]
 
-    async def synthesize_and_play(self, message: str) -> None:
+                elif name == "audio_query":
+                    text = arguments.get("text", "")
+                    speaker = arguments.get("speaker")
+                    if not text:
+                        self.logger.warning("Empty text received for audio_query")
+                        return [types.TextContent(type="text", text="Text is empty")]
+                    query_result = self.voicevox_client.audio_query(text=text, speaker=speaker)
+                    # MCPでは通常、JSONシリアライズ可能な形式で返す
+                    return [types.ObjectContent(type="object", object=query_result)]
+
+                elif name == "synthesis":
+                    query = arguments.get("query")
+                    speaker = arguments.get("speaker")
+                    if not query:
+                        self.logger.warning("No query provided for synthesis")
+                        return [types.TextContent(type="text", text="Query is not provided")]
+                    
+                    # queryが文字列で渡された場合、辞書に変換する必要があるか確認
+                    # MCPクライアントからの入力形式に依存
+                    if isinstance(query, str):
+                        import json
+                        try:
+                            query = json.loads(query)
+                        except json.JSONDecodeError:
+                            self.logger.error("Invalid JSON format for query in synthesis")
+                            return [types.TextContent(type="text", text="Invalid JSON format for query")]
+
+                    wav_bytes = self.voicevox_client.synthesis(query=query, speaker=speaker)
+                    wav_base64 = base64.b64encode(wav_bytes).decode('utf-8')
+                    # Base64エンコードされた音声データを返す
+                    # types.BinaryContent があればそちらを使うのが適切かもしれないが、MCPのバージョンや詳細仕様による
+                    # ここでは ObjectContent を使い、キーを指定して返す
+                    return [types.ObjectContent(type="object", object={"audio_content": wav_base64})]
+
+
+                elif name == "speakers":
+                    speakers_list = self.voicevox_client.get_speakers()
+                    # MCPでは通常、JSONシリアライズ可能な形式で返す
+                    return [types.ObjectContent(type="object", object=speakers_list)] # types.ArrayContent があればより適切
+
+                else:
+                    self.logger.warning(f"Unknown tool: {name}")
+                    return [types.TextContent(type="text", text=f"Unknown tool: {name}")]
+
+            except Exception as e:
+                self.logger.error(f"Error in tool {name}: {str(e)}", exc_info=True) # exc_info=True を追加してスタックトレースをログに出力
+                return [types.TextContent(type="text", text=f"Error processing tool {name}: {str(e)}")]
+
+
+    async def synthesize_and_play(self, message: str, speaker: Optional[str] = None) -> None: # speaker引数を追加
         """
         テキストを音声合成して再生します。
         
         Args:
             message: 音声合成するテキスト
+            speaker: (オプショナル) 話者ID
         """
-        self.logger.info(f"Synthesizing message: {message}")
+        self.logger.info(f"Synthesizing message: '{message}' with speaker: {speaker if speaker else 'default'}")
         
         # テキストの前処理
         processed_message = self._preprocess_text(message)
         
         # Audio Queryの取得
-        query = self.voicevox_client.audio_query(processed_message)
+        query = self.voicevox_client.audio_query(text=processed_message, speaker=speaker) # speaker引数を渡す
         
         # 音声合成
-        wav_bytes = self.voicevox_client.synthesis(query)
+        wav_bytes = self.voicevox_client.synthesis(query=query, speaker=speaker) # speaker引数を渡す
         
         # 音声再生
         await self._play_audio(wav_bytes)
@@ -217,7 +315,7 @@ class MCPServer(Server):
         for line in lines:
             line = line.strip()
             if line:
-                if not line.endswith('。'):
+                if not line.endswith('。') and not line.endswith('！') and not line.endswith('?'): # 句読点の種類を増やす
                     line += '。'
                 processed_lines.append(line)
         
@@ -230,8 +328,14 @@ class MCPServer(Server):
         Args:
             wav_bytes: 再生するWAVデータのバイト列
         """
-        with BytesIO(wav_bytes) as wav_io:
-            with wave.open(wav_io, 'rb') as wav_read:
-                wave_obj = sa.WaveObject.from_wave_read(wav_read)
-                play_obj = wave_obj.play()   # 非同期再生
-                play_obj.wait_done()
+        try: # simpleaudio の再生エラーをキャッチ
+            with BytesIO(wav_bytes) as wav_io:
+                with wave.open(wav_io, 'rb') as wav_read:
+                    wave_obj = sa.WaveObject.from_wave_read(wav_read)
+                    play_obj = wave_obj.play()   # 非同期再生
+                    play_obj.wait_done()
+        except Exception as e:
+            self.logger.error(f"Error playing audio: {str(e)}", exc_info=True)
+            # ここでエラーを再raiseするか、あるいは TextContent でエラーを返すかは設計次第
+            # synthesize_and_play を呼び出す call_tool 側でエラーハンドリングしているので、ここではログ出力に留める
+            raise # 再度raiseして上位のエラーハンドリングに任せる

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -11,7 +11,7 @@ import os
 import wave
 from datetime import datetime
 from io import BytesIO
-from typing import Any, Dict, Optional, List # List を追加
+from typing import Any, Dict, Optional, List, Union # Union を追加
 import wave, simpleaudio as sa
 import base64 # base64 を追加
 
@@ -76,12 +76,12 @@ class MCPServer(Server):
         
         # ロガーの設定
         logger = logging.getLogger("mcp_server")
-        logger.setLevel(logging.INFO)
+        logger.setLevel(logging.DEBUG)  # DEBUG レベルに変更
         
         # ファイルハンドラの設定
         log_file = os.path.join(log_dir, f"mcp_server_{datetime.now().strftime('%Y%m%d')}.log")
         file_handler = logging.FileHandler(log_file)
-        file_handler.setLevel(logging.INFO)
+        file_handler.setLevel(logging.DEBUG)  # DEBUG レベルに変更
         
         # フォーマッタの設定
         formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
@@ -146,6 +146,15 @@ class MCPServer(Server):
                     }
                 ),
                 types.Tool(
+                    name="speakers",
+                    description="利用可能な話者の一覧を取得します",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {},
+                        "required": []
+                    }
+                ),
+                types.Tool(
                     name="audio_query",
                     description="テキストから音声合成用のクエリを生成します",
                     inputSchema={
@@ -155,17 +164,11 @@ class MCPServer(Server):
                             "speaker": {"type": "string", "description": "（オプショナル）話者ID"}
                         },
                         "required": ["text"]
-                    },
-                    outputSchema={ # outputSchema を追加
-                        "type": "object",
-                        "properties": {
-                            "query": {"type": "object", "description": "音声合成用クエリ"}
-                        }
                     }
                 ),
                 types.Tool(
-                    name="synthesis",
-                    description="音声合成用のクエリからWAV音声データを生成します",
+                    name="synthesizeFromQueryAndPlay",
+                    description="音声クエリからWAVデータを生成して再生します",
                     inputSchema={
                         "type": "object",
                         "properties": {
@@ -173,47 +176,17 @@ class MCPServer(Server):
                             "speaker": {"type": "string", "description": "（オプショナル）話者ID"}
                         },
                         "required": ["query"]
-                    },
-                    outputSchema={ # outputSchema を追加
-                        "type": "object",
-                        "properties": {
-                            "audio_content": {"type": "string", "format": "byte", "description": "Base64エンコードされたWAV音声データ"}
-                        }
                     }
                 ),
-                types.Tool(
-                    name="speakers",
-                    description="利用可能な話者の一覧を取得します",
-                    inputSchema={}, # inputSchema を空のobjectに変更
-                    outputSchema={ # outputSchema を追加
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                                "speaker_uuid": {"type": "string"},
-                                "styles": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "name": {"type": "string"},
-                                            "id": {"type": "integer"}
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                )
             ]
         
         @self.call_tool()
-        async def handle_call_tool(name: str, arguments: Dict[str, Any]) -> List[types.Content]: # 戻り値の型ヒントを修正
+        async def handle_call_tool(name: str, arguments: Dict[str, Any]) -> List[Union[types.TextContent, types.ImageContent, types.EmbeddedResource]]: # 戻り値の型ヒントを修正
             """
             指定されたツールを実行します。
             """
             self.logger.info(f"Tool called: {name} with arguments: {arguments}")
+            self.logger.debug(f"Entering handle_call_tool: {name}")  # DEBUGログ追加
             try:
                 if name == "synthesizeAndPlay":
                     message = arguments.get("message", "")
@@ -232,37 +205,40 @@ class MCPServer(Server):
                         return [types.TextContent(type="text", text="Text is empty")]
                     query_result = self.voicevox_client.audio_query(text=text, speaker=speaker)
                     # MCPでは通常、JSONシリアライズ可能な形式で返す
-                    return [types.ObjectContent(type="object", object=query_result)]
+                    import json
+                    return [types.TextContent(type="text", text=json.dumps(query_result, ensure_ascii=False, indent=2))]
 
-                elif name == "synthesis":
+                elif name == "synthesizeFromQueryAndPlay":
                     query = arguments.get("query")
                     speaker = arguments.get("speaker")
                     if not query:
-                        self.logger.warning("No query provided for synthesis")
+                        self.logger.warning("No query provided for synthesizeFromQueryAndPlay")
                         return [types.TextContent(type="text", text="Query is not provided")]
                     
-                    # queryが文字列で渡された場合、辞書に変換する必要があるか確認
-                    # MCPクライアントからの入力形式に依存
+                    # queryが文字列で渡された場合、辞書に変換
                     if isinstance(query, str):
                         import json
                         try:
                             query = json.loads(query)
                         except json.JSONDecodeError:
-                            self.logger.error("Invalid JSON format for query in synthesis")
+                            self.logger.error("Invalid JSON format for query in synthesizeFromQueryAndPlay")
                             return [types.TextContent(type="text", text="Invalid JSON format for query")]
 
+                    # WAVデータ生成
                     wav_bytes = self.voicevox_client.synthesis(query=query, speaker=speaker)
-                    wav_base64 = base64.b64encode(wav_bytes).decode('utf-8')
-                    # Base64エンコードされた音声データを返す
-                    # types.BinaryContent があればそちらを使うのが適切かもしれないが、MCPのバージョンや詳細仕様による
-                    # ここでは ObjectContent を使い、キーを指定して返す
-                    return [types.ObjectContent(type="object", object={"audio_content": wav_base64})]
-
+                    
+                    # 音声再生
+                    await self._play_audio(wav_bytes)
+                    
+                    return [types.TextContent(type="text", text="音声クエリからの合成と再生が完了しました")]
 
                 elif name == "speakers":
                     speakers_list = self.voicevox_client.get_speakers()
                     # MCPでは通常、JSONシリアライズ可能な形式で返す
-                    return [types.ObjectContent(type="object", object=speakers_list)] # types.ArrayContent があればより適切
+                    # スキーマに合わせてobject形式で返す
+                    import json
+                    result = {"speakers": speakers_list}
+                    return [types.TextContent(type="text", text=json.dumps(result, ensure_ascii=False, indent=2))]
 
                 else:
                     self.logger.warning(f"Unknown tool: {name}")

--- a/src/voicevox_client.py
+++ b/src/voicevox_client.py
@@ -5,7 +5,7 @@ ex.
     from src.voicevox_client import VoicevoxClient
     import io, wave, simpleaudio as sa
 
-    vvc = VoicevoxClient(speaker="8")   # speaker id を`8`を利用する
+    vvc = VoicevoxClient(default_speaker="8")   # speaker id を`8`を利用する
     query = vvc.audio_query(text=message)   # メッセージデータのみを設定し発音内容に変換
     wav_bytes = vvc.synthesis(query=query)  # wav音声データのバイナリデータを取得
     with io.BytesIO(wav_bytes) as wav_io:
@@ -16,38 +16,44 @@ ex.
 """
 
 import requests
+from typing import Optional, Any, Dict, List # Any, Dict, List を追加
 
 HOST = "127.0.0.1"
 PORT = "50021"
-SPEAKER = "3" # Changed from "1" to an available speaker ID (Zundamon Normal)
+DEFAULT_SPEAKER = "3" # Changed from "1" to an available speaker ID (Zundamon Normal)
 
 class VoicevoxClient:
 
-    def __init__(self, host=HOST, port=PORT, speaker=SPEAKER):
-        if host is None or len(host) == 0:
-            self.host = HOST
-        else:
-            self.host = host
-        if port is None or len(port) == 0:
-            self.port = PORT
-        else:
-            self.port = port
-        if speaker is None or len(speaker) == 0:
-            self.speaker = SPEAKER
-        else:
-            self.speaker = speaker
+    def __init__(self, host: str = HOST, port: str = PORT, default_speaker: str = DEFAULT_SPEAKER):
+        self.host: str = host if host else HOST
+        self.port: str = port if port else PORT
+        self.default_speaker: str = default_speaker if default_speaker else DEFAULT_SPEAKER
 
-    def audio_query(self, text: str):
+    def audio_query(self, text: str, speaker: Optional[str] = None) -> Dict[str, Any]:
+        params = {
+            "text": text,
+            "speaker": speaker if speaker is not None else self.default_speaker,
+        }
         response = requests.post(
             f"http://{self.host}:{self.port}/audio_query",
-            params={
-                "text": text,
-                "speaker": self.speaker,
-            }
+            params=params
         )
+        response.raise_for_status()
         return response.json()
 
-    def get_speakers(self):
+    def synthesis(self, query: Dict[str, Any], speaker: Optional[str] = None) -> bytes:
+        params = {
+            "speaker": speaker if speaker is not None else self.default_speaker,
+        }
+        response = requests.post(
+            f"http://{self.host}:{self.port}/synthesis",
+            params=params,
+            json=query
+        )
+        response.raise_for_status()
+        return response.content
+
+    def get_speakers(self) -> List[Dict[str, Any]]:
         """利用可能な話者とそのスタイルを取得します"""
         response = requests.get(
             f"http://{self.host}:{self.port}/speakers"
@@ -55,15 +61,3 @@ class VoicevoxClient:
         response.raise_for_status() # エラーチェック
         return response.json()
 
-    def synthesis(self, query):
-        url = f"http://{self.host}:{self.port}/synthesis"
-        params = {"speaker": self.speaker}
-
-        # 500になったケースのtryを書く予定
-        response = requests.post(
-            url,
-            params=params,
-            json=query
-        )
-        response.raise_for_status()
-        return response.content


### PR DESCRIPTION
VOICEVOX Engineの機能をより細かく利用できるようにするため、以下のツールを追加・修正しました。

- **`src/voicevox_client.py` の変更点:**
    - `audio_query` および `synthesis` メソッドにオプショナルな `speaker` 引数を追加しました。
    - クラス初期化時の `speaker` 引数を `default_speaker` にリネームし、役割を明確化しました。
    - 型ヒントを改善し、より堅牢なコードにしました。
- **`src/mcp_server.py` の変更点:**
    - 新たに以下のMCPツールを実装しました:
        - `audio_query`: テキストから音声合成用のクエリを生成します。
        - `synthesis`: 音声合成用のクエリからWAV音声データ（Base64エンコード文字列）を生成します。
        - `speakers`: 利用可能な話者の一覧を取得します。
    - 既存の `synthesizeAndPlay` ツールも、`speaker`引数を受け付けられるように修正しました。
    - 各ツールの入力・出力スキーマを定義しました。

これにより、クライアントはVOICEVOXの機能をより柔軟に利用できるようになります。