### PR TITLE
Fix importerror in mcp_server.py

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -17,7 +17,7 @@ import wave, simpleaudio as sa
 import sounddevice as sd
 from mcp.server import Server
 
-from src.voicevox_client import VoicevoxClient
+from .voicevox_client import VoicevoxClient
 
 
 class MCPServer(Server):


### PR DESCRIPTION
Fixed an import error in `mcp_server.py` by changing to a relative import. This allows the server to start correctly when run as a module.